### PR TITLE
Change Ew color from light blue (MH, #149ece) to purple (#4f33df) for FL & GA

### DIFF
--- a/WME-FC-Layer.js
+++ b/WME-FC-Layer.js
@@ -809,7 +809,7 @@
       supportsPagination: false,
       defaultColors: {
         Fw: '#ff00c5',
-        Ew: '#149ece',
+        Ew: '#4f33df',
         MH: '#149ece',
         mH: '#4ce600',
         PS: '#cfae0e',
@@ -850,7 +850,7 @@
       supportsPagination: true,
       defaultColors: {
         Fw: '#ff00c5',
-        Ew: '#149ece',
+        Ew: '#4f33df',
         MH: '#149ece',
         mH: '#4ce600',
         PS: '#cfae0e',


### PR DESCRIPTION
Was discussed on #scripts in Waze USA in Discord, driving79 recommended we change it to purple. Having a distinction between the coloring used for MH and Expressways seems worthwhile, but this could always be overridden by SER/FL/GA leadership (Alabama is the remaining state in SER and uses purple for Ew).